### PR TITLE
Add GitHub Skills activity to signup page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Resolves Issue #6

This PR adds the missing **GitHub Skills** activity that was announced by the principal and is urgently needed for student registrations.

## 📝 Changes Made

- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Activity details:
  - **Description**: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications
  - **Schedule**: Wednesdays, 3:30 PM - 5:00 PM
  - **Max Participants**: 25 students
  - **Current Participants**: Empty list (ready for student registrations)

## ✅ Why This is Important

- **Time-sensitive**: Registrations close by the end of this week
- **Educational Impact**: Part of the GitHub Certifications program that helps with college applications
- **Student Demand**: Multiple students are waiting to sign up for this officially announced activity

## 🧪 Testing

The activity follows the same structure as existing activities and will be immediately available on the signup page once merged.

Fixes #6